### PR TITLE
Updating MANIFEST.in to include maskclip bpe vocab file.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,3 +3,4 @@ recursive-include featup/adaptive_conv_cuda *.cpp *.cu *.h
 recursive-include featup/configs *.yaml
 recursive-include featup/featurizers *.py
 recursive-include sample-images *
+include featup/featurizers/maskclip/bpe_simple_vocab_16e6.txt.gz

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ setup(
     name='featup',
     version='0.1.2',
     packages=find_packages(),
+    include_package_data=True,
     install_requires=[
         'torch',
         'kornia',


### PR DESCRIPTION
### Description

When installing the package using setuptools and pip, the vocabulary file required by maskclip ([bpe_simple_vocab_16e6.txt.gz](https://github.com/mhamilton723/FeatUp/blob/main/featup/featurizers/maskclip/bpe_simple_vocab_16e6.txt.gz)) is not included in the distribution package since it's not specified in the [manifest file](https://setuptools.pypa.io/en/latest/userguide/miscellaneous.html#using-manifest-in). This issue was also raised and described in #47. Trying to use the maskclip model after installing FeatUp currently results in a `FileNotFoundError` error for the missing vocabulary file.

### Solution

This pull request makes three modifications to resolve the installation:

1. Specify the vocabulary file as one to be installed along with python source files by listing `bpe_simple_vocab_16e6.txt.gz` in the `MANIFEST.in` file. [[Link to line]](https://github.com/opipari/FeatUp/blob/6913e76b19b0295d3856c599162e96686d6e0a2f/MANIFEST.in#L6)
2. Renaming `manifest.in` to `MANIFEST.in` so it is used by setuptools during the installation process.
3. Setting the `include_package_data` flag to `True` within setup.py to ensure the manifest is used and the vocab file is installed. [[Link to line]](https://github.com/opipari/FeatUp/blob/6913e76b19b0295d3856c599162e96686d6e0a2f/setup.py#L8)

#### Thanks
Thanks for considering this pull request and this awesome project!